### PR TITLE
Feature/mem cache store (#1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ gem "uglifier", "~> 4.1"
 group :development, :test do
   gem "byebug", "~> 10.0", platform: :mri
 
-  gem "decidim-dev", Decidim::TermCustomizer::DECIDIM_VERSION
   gem "decidim-consultations", Decidim::TermCustomizer::DECIDIM_VERSION
+  gem "decidim-dev", Decidim::TermCustomizer::DECIDIM_VERSION
 end
 
 group :development do

--- a/app/commands/decidim/term_customizer/admin/import_translation_keys.rb
+++ b/app/commands/decidim/term_customizer/admin/import_translation_keys.rb
@@ -42,7 +42,8 @@ module Decidim
             form.current_organization.available_locales.map do |locale|
               attrs = {
                 key: key,
-                locale: locale
+                locale: locale,
+                translation_set_id: translation_set.id
               }
               next unless TermCustomizer::Translation.find_by(attrs).nil?
 

--- a/app/commands/decidim/term_customizer/admin/import_translation_keys.rb
+++ b/app/commands/decidim/term_customizer/admin/import_translation_keys.rb
@@ -43,7 +43,7 @@ module Decidim
               attrs = {
                 key: key,
                 locale: locale,
-                translation_set_id: translation_set.id
+                translation_set_id: form.translation_set.id
               }
               next unless TermCustomizer::Translation.find_by(attrs).nil?
 

--- a/decidim-term_customizer.gemspec
+++ b/decidim-term_customizer.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "decidim-admin", Decidim::TermCustomizer::DECIDIM_VERSION
   spec.add_dependency "decidim-core", Decidim::TermCustomizer::DECIDIM_VERSION
 
+  spec.add_development_dependency "decidim-consultations", Decidim::TermCustomizer::DECIDIM_VERSION
   spec.add_development_dependency "decidim-dev", Decidim::TermCustomizer::DECIDIM_VERSION
   spec.add_development_dependency "decidim-participatory_processes", Decidim::TermCustomizer::DECIDIM_VERSION
   spec.add_development_dependency "decidim-proposals", Decidim::TermCustomizer::DECIDIM_VERSION
-  spec.add_development_dependency "decidim-consultations", Decidim::TermCustomizer::DECIDIM_VERSION
 end

--- a/lib/decidim/term_customizer/loader.rb
+++ b/lib/decidim/term_customizer/loader.rb
@@ -56,7 +56,9 @@ module Decidim
       # Clears the translations cache only for the current context defined by
       # the resolver.
       def clear_cache
-        Rails.cache.delete_matched("#{cache_key_base}/*")
+        return Rails.cache.delete_matched("#{cache_key_base}/*") unless mem_cache_store?
+
+        Rails.cache.delete(cache_key_base)
       end
 
       private
@@ -80,6 +82,10 @@ module Decidim
           end
 
         "decidim_term_customizer/#{main_key}"
+      end
+
+      def mem_cache_store?
+        Rails.application.config.cache_store == :mem_cache_store
       end
     end
   end

--- a/spec/commands/decidim/term_customizer/admin/import_translation_keys_spec.rb
+++ b/spec/commands/decidim/term_customizer/admin/import_translation_keys_spec.rb
@@ -59,11 +59,19 @@ describe Decidim::TermCustomizer::Admin::ImportTranslationKeys do
           Decidim::TermCustomizer::Translation, :count
         ).by(12)
 
-        keys.each do |key|
-          expect(Decidim::TermCustomizer::Translation.where(
-            key: key
-          ).count).to eq(3)
-        end
+        keys.each { |key| expect(Decidim::TermCustomizer::Translation.where(key: key).count).to eq(3) }
+      end
+    end
+
+    context "when the key exists in another translation set" do
+      let!(:translation_set_2) { create(:translation_set, organization: organization) }
+      let(:key) { "decidim.admin.actions.new_translation" }
+      let!(:translation) { create(:translation, translation_set: translation_set_2, locale: :en, key: key) }
+
+      it "adds the translation" do
+        command.call
+
+        expect(Decidim::TermCustomizer::Translation.where(key: key).count).to eq(4)
       end
     end
   end

--- a/spec/lib/decidim/term_customizer/engine_spec.rb
+++ b/spec/lib/decidim/term_customizer/engine_spec.rb
@@ -102,9 +102,7 @@ describe Decidim::TermCustomizer::Engine do
       allow(dummy_job).to receive(:job_id).and_return(1)
       allow(dummy_job).to receive(:queue_name).and_return("queue")
       allow(dummy_job).to receive(:arguments).and_return(arguments)
-    end
 
-    before do
       expect(Decidim::TermCustomizer::I18nBackend).to receive(:new).and_return(dummy_backend)
 
       run_initializer

--- a/spec/lib/decidim/term_customizer/loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/loader_spec.rb
@@ -107,6 +107,59 @@ describe Decidim::TermCustomizer::Loader do
         subject.clear_cache
       end
     end
+
+    context "when using mem_cache_store" do
+      before do
+        allow(Rails.application.config).to receive(:cache_store).and_return(:mem_cache_store)
+      end
+
+      context "without organization" do
+        let(:organization) { nil }
+
+        it "clears cache with correct key" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/system"
+          )
+
+          subject.clear_cache
+        end
+      end
+
+      context "with organization" do
+        it "clears cache with correct key" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+
+          subject.clear_cache
+        end
+      end
+
+      context "with organization and space" do
+        let(:space) { create(:participatory_process, organization: organization) }
+
+        it "clears cache with correct key" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+
+          subject.clear_cache
+        end
+      end
+
+      context "with organization, space and component" do
+        let(:space) { create(:participatory_process, organization: organization) }
+        let(:component) { create(:proposal_component, participatory_space: space) }
+
+        it "clears cache with correct key" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+
+          subject.clear_cache
+        end
+      end
+    end
   end
 
   def flatten_hash(hash)


### PR DESCRIPTION
This module is an excellent contribution to the Decidim universe, unfortunately, it was incompatible with mem_cache_store that we use in production. Feel free to do a review if something is not crystal clear, or not good.

* Add compatibility with mem_cache_store
*  Do not define multiple hooks in the same example group
* Gem / dependencies should be sorted in an alphabetical order.