### PR TITLE
Update DECIDIM_VERSION to be more flexible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     decidim-term_customizer (0.18.0)
-      decidim-admin (~> 0.18.0)
-      decidim-core (~> 0.18.0)
+      decidim-admin (>= 0.18.0)
+      decidim-core (>= 0.18.0)
 
 GEM
   remote: https://rubygems.org/
@@ -746,9 +746,9 @@ DEPENDENCIES
   byebug (~> 10.0)
   codecov
   dalli (~> 2.7, >= 2.7.10)
-  decidim (~> 0.18.0)
-  decidim-consultations (~> 0.18.0)
-  decidim-dev (~> 0.18.0)
+  decidim (>= 0.18.0)
+  decidim-consultations (>= 0.18.0)
+  decidim-dev (>= 0.18.0)
   decidim-term_customizer!
   faker (~> 1.9)
   letter_opener_web (~> 1.3)

--- a/lib/decidim/term_customizer/version.rb
+++ b/lib/decidim/term_customizer/version.rb
@@ -3,6 +3,6 @@
 module Decidim
   module TermCustomizer
     VERSION = "0.18.0"
-    DECIDIM_VERSION = "~> 0.18.0"
+    DECIDIM_VERSION = ">= 0.18.0"
   end
 end


### PR DESCRIPTION
At CodiTramuntana we make heavy use of this gem (it's great!), as you can see here:
https://github.com/mainio/decidim-module-term_customizer/network/dependents

It would be great if the `DECIDIM_VERSION` was less restrictive as we like to update our applications fairly soon; we are now upgrading to `decidim 0.19.0` but we find that we need to keep a fork as the original repo does not allow us to upgrade.