### PR TITLE
Feature/fix translation regex

### DIFF
--- a/app/forms/decidim/term_customizer/admin/translation_form.rb
+++ b/app/forms/decidim/term_customizer/admin/translation_form.rb
@@ -14,7 +14,7 @@ module Decidim
         translatable_attribute :value, String
 
         validates :key, presence: true
-        validates :key, format: { with: %r{\A([a-z0-9_/]+\.?)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
+        validates :key, format: { with: %r{\A([a-z0-9_/]+\.)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
         validates :value, translatable_presence: true
         validate :key_uniqueness
 

--- a/app/forms/decidim/term_customizer/admin/translation_form.rb
+++ b/app/forms/decidim/term_customizer/admin/translation_form.rb
@@ -14,7 +14,7 @@ module Decidim
         translatable_attribute :value, String
 
         validates :key, presence: true
-        validates :key, format: { with: %r{\A([a-z0-9_/]+\.)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
+        validates :key, format: { with: %r{\A([a-z0-9_/\?\-]+\.)*[a-z0-9_/\?\-]+\z} }, unless: -> { key.blank? }
         validates :value, translatable_presence: true
         validate :key_uniqueness
 

--- a/app/models/decidim/term_customizer/translation.rb
+++ b/app/models/decidim/term_customizer/translation.rb
@@ -10,7 +10,7 @@ module Decidim
 
       validates :locale, presence: true
       validates :key, presence: true
-      validates :key, format: { with: %r{\A([a-z0-9_/]+\.)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
+      validates :key, format: { with: %r{\A([a-z0-9_/\?\-]+\.)*[a-z0-9_/\?\-]+\z} }, unless: -> { key.blank? }
       validates :key, uniqueness: { scope: [:translation_set, :locale] }, unless: -> { key.blank? }
 
       class << self

--- a/app/models/decidim/term_customizer/translation.rb
+++ b/app/models/decidim/term_customizer/translation.rb
@@ -10,7 +10,7 @@ module Decidim
 
       validates :locale, presence: true
       validates :key, presence: true
-      validates :key, format: { with: %r{\A([a-z0-9_/]+\.?)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
+      validates :key, format: { with: %r{\A([a-z0-9_/]+\.)*[a-z0-9_/]+\z} }, unless: -> { key.blank? }
       validates :key, uniqueness: { scope: [:translation_set, :locale] }, unless: -> { key.blank? }
 
       class << self

--- a/spec/models/decidim/term_customizer/translation_spec.rb
+++ b/spec/models/decidim/term_customizer/translation_spec.rb
@@ -34,6 +34,12 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when key contains special characters" do
+        let(:key) { "translation.test-key?" }
+
+        it { is_expected.to be_valid }
+      end
+
       context "when key is invalid" do
         let(:key) { "test.test.test.test.test.test.test.test.test-key?" }
 

--- a/spec/models/decidim/term_customizer/translation_spec.rb
+++ b/spec/models/decidim/term_customizer/translation_spec.rb
@@ -41,7 +41,7 @@ module Decidim
       end
 
       context "when key is invalid" do
-        let(:key) { "test.test.test.test.test.test.test.test.test-key?" }
+        let(:key) { "test.test.test.test.test.test.test.test.testA" }
 
         it "does not run exponentially long" do
           limit = 3.seconds.from_now

--- a/spec/models/decidim/term_customizer/translation_spec.rb
+++ b/spec/models/decidim/term_customizer/translation_spec.rb
@@ -34,6 +34,16 @@ module Decidim
         it { is_expected.to be_invalid }
       end
 
+      context "when key is invalid" do
+        let(:key) { "test.test.test.test.test.test.test.test.test-key?" }
+
+        it "does not run exponentially long" do
+          limit = 3.seconds.from_now
+          expect(subject).to be_invalid
+          expect(Time.now).to be < limit
+        end
+      end
+
       it_behaves_like "translation validatable"
     end
   end


### PR DESCRIPTION
Two Fixes within the current translation regex:

1. Adding more symbols (? and -) to the regex to support existing decidim translation keys.
1. Fixing exponential runtime for failing regexes by removing the unnecessary optional dot.
```bash
> time ruby -e 'puts /\A([a-z0-9_\/]+\.?)*[a-z0-9_\/]+\z/.match("test.test.test.test.test.test.test.test.test-key?")'
real    0m7.714s
user    0m7.688s
sys     0m0.031s

> time ruby -e 'puts /\A([a-z0-9_\/]+\.)*[a-z0-9_\/]+\z/.match("test.test.test.test.test.test.test.test.test-key?")'
real    0m0.086s
user    0m0.063s
sys     0m0.016s
```