### PR TITLE
Fix participatory space not being retrieved properly

### DIFF
--- a/lib/decidim/term_customizer/context/controller_context.rb
+++ b/lib/decidim/term_customizer/context/controller_context.rb
@@ -16,10 +16,11 @@ module Decidim
           # controller using its private method. In some edge cases this may not
           # be implemented (https://github.com/mainio/decidim-module-term_customizer/issues/28)
           # in which case we do not have access to the participatory space.
-          if controller.respond_to?(:current_participatory_space, true)
-            @space = controller.send(
-              :current_participatory_space
-            )
+          unless controller.respond_to?(:current_participatory_space)
+            controller.define_singleton_method(:public_current_participatory_space) { current_participatory_space }
+            @space = controller.try(:public_current_participatory_space)
+          else
+            @space = controller.try(:current_participatory_space)
           end
           @space ||= env["decidim.current_participatory_space"]
 

--- a/lib/decidim/term_customizer/context/controller_context.rb
+++ b/lib/decidim/term_customizer/context/controller_context.rb
@@ -17,7 +17,9 @@ module Decidim
           # be implemented (https://github.com/mainio/decidim-module-term_customizer/issues/28)
           # in which case we do not have access to the participatory space.
           unless controller.respond_to?(:current_participatory_space)
-            controller.define_singleton_method(:public_current_participatory_space) { try(:current_participatory_space) }
+            controller.define_singleton_method(:public_current_participatory_space) do
+              current_participatory_space if self.respond_to? :current_participatory_space, true
+            end
             @space = controller.public_current_participatory_space
           else
             @space = controller.try(:current_participatory_space)

--- a/lib/decidim/term_customizer/context/controller_context.rb
+++ b/lib/decidim/term_customizer/context/controller_context.rb
@@ -17,8 +17,8 @@ module Decidim
           # be implemented (https://github.com/mainio/decidim-module-term_customizer/issues/28)
           # in which case we do not have access to the participatory space.
           unless controller.respond_to?(:current_participatory_space)
-            controller.define_singleton_method(:public_current_participatory_space) { current_participatory_space }
-            @space = controller.try(:public_current_participatory_space)
+            controller.define_singleton_method(:public_current_participatory_space) { try(:current_participatory_space) }
+            @space = controller.public_current_participatory_space
           else
             @space = controller.try(:current_participatory_space)
           end


### PR DESCRIPTION
Add singleton method to access private method current_participatory_space. Solves main participatory spaces public show view not showing translations properly.
Before fix:
![image](https://user-images.githubusercontent.com/56717126/101777597-01682b00-3af3-11eb-95a7-457b158a563f.png)
![image](https://user-images.githubusercontent.com/56717126/101777605-07f6a280-3af3-11eb-8366-85f634ed2b50.png)

After fix:
![image](https://user-images.githubusercontent.com/56717126/101777517-e09fd580-3af2-11eb-983f-112d09881eb8.png)
![image](https://user-images.githubusercontent.com/56717126/101777549-e8f81080-3af2-11eb-81f0-54b5a9120e95.png)
