### PR TITLE
Fix deprecation warning about positional arguments in Faker

### DIFF
--- a/lib/decidim/term_customizer/test/factories.rb
+++ b/lib/decidim/term_customizer/test/factories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   # Create as a sequence to avoid key collisions
   sequence :translation_key do |n|
-    "#{::Faker::Lorem.words(rand(1..3)).join(".").downcase}.tr#{n}"
+    "#{::Faker::Lorem.words(number: rand(1..3)).join(".").downcase}.tr#{n}"
   end
 
   factory :translation_set, class: Decidim::TermCustomizer::TranslationSet do
@@ -31,7 +31,7 @@ FactoryBot.define do
   factory :translation, class: Decidim::TermCustomizer::Translation do
     locale { :en }
     key { generate(:translation_key) }
-    value { ::Faker::Lorem.words(rand(1..10)).join(" ") }
+    value { ::Faker::Lorem.words(number: rand(1..10)).join(" ") }
     translation_set { create(:translation_set) }
   end
 

--- a/spec/forms/decidim/term_customizer/admin/translation_form_spec.rb
+++ b/spec/forms/decidim/term_customizer/admin/translation_form_spec.rb
@@ -12,7 +12,7 @@ module Decidim
         let(:translation_set) { create(:translation_set, organization: organization) }
         let(:key) { "translation.key" }
         let(:locale) { I18n.locale }
-        let(:value) { Decidim::Faker::Localized.sentence(3) }
+        let(:value) { Decidim::Faker::Localized.sentence(word_count: 3) }
         let(:params) { { key: key, value: value } }
 
         let(:form) do

--- a/spec/forms/decidim/term_customizer/admin/translation_set_form_spec.rb
+++ b/spec/forms/decidim/term_customizer/admin/translation_set_form_spec.rb
@@ -9,7 +9,7 @@ module Decidim
         subject { form }
 
         let(:organization) { create(:organization) }
-        let(:name) { Decidim::Faker::Localized.sentence(3) }
+        let(:name) { Decidim::Faker::Localized.sentence(word_count: 3) }
         let(:params) { { name: name } }
 
         let(:form) do

--- a/spec/forms/decidim/term_customizer/admin/translations_destroy_form_spec.rb
+++ b/spec/forms/decidim/term_customizer/admin/translations_destroy_form_spec.rb
@@ -59,7 +59,7 @@ module Decidim
                   translation_set: translation_set,
                   locale: locale,
                   key: tr.key,
-                  value: Decidim::Faker::Localized.sentence(3)
+                  value: Decidim::Faker::Localized.sentence(word_count: 3)
                 )
               end
             end

--- a/spec/models/decidim/term_customizer/translation_spec.rb
+++ b/spec/models/decidim/term_customizer/translation_spec.rb
@@ -20,7 +20,7 @@ module Decidim
       end
       let(:locale) { :en }
       let(:key) { "translation.key" }
-      let(:value) { ::Faker::Lorem.sentence(3) }
+      let(:value) { ::Faker::Lorem.sentence(word_count: 3) }
 
       it { is_expected.to be_valid }
 


### PR DESCRIPTION
There were these kinds of warnings when running the specs:

> ./decidim-module-term_customizer/spec/models/decidim/term_customizer/translation_spec.rb:23: Passing `word_count` with the 1st argument of `sentence` is deprecated. Use keyword argument like `sentence(word_count: ...)` instead.
>
> To automatically update from positional arguments to keyword arguments,
> install rubocop-faker and run:
>
> rubocop \
>   --require rubocop-faker \
>   --only Faker/DeprecatedArguments \
>   --auto-correct

This PR fixes them 