### PR TITLE
Fix deprecation warning in Dalli

### DIFF
--- a/spec/lib/decidim/term_customizer/loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/loader_spec.rb
@@ -185,10 +185,10 @@ describe Decidim::TermCustomizer::Loader do
     # The DalliStore does not implement `delete_matched` which allows us to
     # test the `clear_cache` functionality when the cache implementation raises
     # a `NoMethodError`.
-    context "when using dalli_store" do
+    context "when using mem_cache_store" do
       before do
         allow(Rails).to receive(:cache).and_return(
-          ActiveSupport::Cache.lookup_store(:dalli_store)
+          ActiveSupport::Cache.lookup_store(:mem_cache_store)
         )
       end
 


### PR DESCRIPTION
There were these kinds of warnings when running the specs:

> DEPRECATION: :dalli_store will be removed in Dalli 3.0.
> Please use Rails' official :mem_cache_store instead.
> https://guides.rubyonrails.org/caching_with_rails.html

This PR fixes them. 