### PR TITLE
Add I18n::Backend::Pluralization into I18nBackend

### DIFF
--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -10,6 +10,7 @@ module Decidim
 
       module Implementation
         include I18n::Backend::Base
+        include I18n::Backend::Pluralization
 
         # Get available locales from the translations hash
         def available_locales

--- a/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
+++ b/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
@@ -26,6 +26,26 @@ describe Decidim::TermCustomizer::I18nBackend do
     }
   end
 
+  let(:pluralize_translations_list) do
+    {
+      en: {
+        decidim: {
+          term1: {
+            one: "Term 1 singular",
+            other: "Term 1 plural"
+          }
+        }
+      },
+      ja: {
+        decidim: {
+          term1: {
+            other: "Term 1 invariant"
+          }
+        }
+      }
+    }
+  end
+
   describe "#available_locales" do
     context "when no translations are available" do
       it "returns an empty result" do
@@ -130,6 +150,22 @@ describe Decidim::TermCustomizer::I18nBackend do
         expect(subject.translate(:fi, "decidim.term2")).to eq("Termi 2")
         expect(subject.translate(:sv, "decidim.term1")).to eq("Term 1")
         expect(subject.translate(:sv, "decidim.term2")).to eq("Term 2")
+      end
+    end
+
+    context "with plural forms" do
+      let(:loader) { double }
+
+      before do
+        allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
+        expect(loader).to receive(:translations_hash).and_return(pluralize_translations_list)
+      end
+
+      it "translates the translation keys correctly" do
+        expect(subject.translate(:en, "decidim.term1", count: 1)).to eq("Term 1 singular")
+        expect(subject.translate(:en, "decidim.term1", count: 2)).to eq("Term 1 plural")
+        expect(subject.translate(:ja, "decidim.term1", count: 1)).to eq("Term 1 invariant")
+        expect(subject.translate(:ja, "decidim.term1", count: 2)).to eq("Term 1 invariant")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
   config.before do
     # Reset the locales to Decidim defaults before each test.
     # Some tests may change this which is why this is important.
-    I18n.available_locales = [:en, :ca, :es]
+    I18n.available_locales = [:en, :ca, :es, :ja]
 
     # Revert the plural keys back to normal
     Decidim::TermCustomizer::PluralFormsManager.plural_keys = original_plural_keys


### PR DESCRIPTION
I have tried this module in a Japanese locale, but the following error occurs.

<img width="1029" alt="i18n-error" src="https://user-images.githubusercontent.com/10401/160049244-83cd504b-bf0b-4634-9492-4faa6a63c9ab.png">

This error occurs when there is only `:other` key for `count: 1`, but since singular and plural are the same in Japanese, it is normal that only `:other` is registered.

This error does not occur in a normal Rails application. I think the reason is due to the additional processing of `I18n::Backend::Pluralization`, which is done by the rails-i18n gem.
On the other hand, `Decidim::TermCustomizer` introduced its own `I18nBackend`, which was not applied to this backend and thus seemed to cause the error.

To solve this, it is easy to add `I18n::Backend::Pluralization` in `I18nBackend`. Is there a problem with making this the default?
