### PR TITLE
Fix database not available (Zeitwerk and Docker error)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -799,6 +801,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -15,7 +15,7 @@ module Decidim
         # Get available locales from the translations hash
         def available_locales
           Translation.available_locales
-        rescue ::ActiveRecord::StatementInvalid
+        rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished, ::PG::ConnectionBad
           []
         end
 

--- a/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
+++ b/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
@@ -80,9 +80,7 @@ describe Decidim::TermCustomizer::I18nBackend do
 
   context "when the translation query raises ActiveRecord::StatementInvalid" do
     it "returns and empty result" do
-      expect(Decidim::TermCustomizer::Translation).to receive(
-                                                        :available_locales
-                                                      ).and_raise(ActiveRecord::ConnectionNotEstablished)
+      allow(Decidim::TermCustomizer::Translation).to receive(:available_locales).and_raise(ActiveRecord::ConnectionNotEstablished)
 
       expect(subject.available_locales).to be_empty
     end
@@ -90,9 +88,7 @@ describe Decidim::TermCustomizer::I18nBackend do
 
   context "when there is no database connection" do
     it "returns and empty result" do
-      expect(Decidim::TermCustomizer::Translation).to receive(
-                                                        :available_locales
-                                                      ).and_raise(PG::ConnectionBad)
+      allow(Decidim::TermCustomizer::Translation).to receive(:available_locales).and_raise(PG::ConnectionBad)
 
       expect(subject.available_locales).to be_empty
     end

--- a/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
+++ b/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
@@ -78,6 +78,26 @@ describe Decidim::TermCustomizer::I18nBackend do
     end
   end
 
+  context "when the translation query raises ActiveRecord::StatementInvalid" do
+    it "returns and empty result" do
+      expect(Decidim::TermCustomizer::Translation).to receive(
+                                                        :available_locales
+                                                      ).and_raise(ActiveRecord::ConnectionNotEstablished)
+
+      expect(subject.available_locales).to be_empty
+    end
+  end
+
+  context "when there is no database connection" do
+    it "returns and empty result" do
+      expect(Decidim::TermCustomizer::Translation).to receive(
+                                                        :available_locales
+                                                      ).and_raise(PG::ConnectionBad)
+
+      expect(subject.available_locales).to be_empty
+    end
+  end
+
   describe "#initialized?" do
     context "when translations are not loaded" do
       it "returns false" do


### PR DESCRIPTION
This modules use a database for initialization but in some cases (Zeitwerk checks or precompilation of assets on Docker) a database is not available.

This P.R. allows usage in theses cases.