### PR TITLE
fix: Devise email translation customization

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -513,6 +513,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
       racc (~> 1.4)
     oauth (1.1.0)
@@ -799,6 +801,7 @@ GEM
     zeitwerk (2.6.11)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/decidim/term_customizer/context/job_context.rb
+++ b/lib/decidim/term_customizer/context/job_context.rb
@@ -8,21 +8,16 @@ module Decidim
         def resolve!
           # Figure out the organization and user through the job arguments if
           # passed for the job.
-          arguments = {
-            organization: nil,
-            space: nil,
-            component: nil,
-            user: nil
-          }
-
+          user = nil
           data[:job].arguments.each do |arg|
-            arg = arg.fetch(:args, []) if arg.is_a?(Hash) && arg.has_key?(:args)
-            arguments = arguments_for(arg)
+            arg = arg[:args].first if arg.is_a?(Hash)
+
+            @organization ||= organization_from_argument(arg)
+            @space ||= space_from_argument(arg)
+            @component ||= component_from_argument(arg)
+            user ||= arg if arg.is_a?(Decidim::User)
           end
 
-          @organization ||= arguments[:organization]
-          @space ||= arguments[:space]
-          @component ||= arguments[:component]
           # In case a component was found, define the space as the component
           # space to avoid any conflicts.
           @space = component.participatory_space if component
@@ -33,27 +28,12 @@ module Decidim
 
           # In case an organization could not be resolved any other way, check
           # it through the user (if the user was passed).
-          @organization ||= arguments[:user]&.organization if arguments[:user]
+          @organization ||= user.organization if user
         end
 
         # rubocop:enable Metrics/PerceivedComplexity
 
         protected
-
-        def arguments_for(args)
-          return conf_for_arg(args.last) if args.is_a?(Array)
-
-          conf_for_arg(args)
-        end
-
-        def conf_for_arg(arg)
-          {
-            organization: organization_from_argument(arg),
-            space: space_from_argument(arg),
-            component: component_from_argument(arg),
-            user: arg.is_a?(Decidim::User) ? arg : nil
-          }
-        end
 
         def organization_from_argument(arg)
           return arg if arg.is_a?(Decidim::Organization)

--- a/lib/decidim/term_customizer/context/job_context.rb
+++ b/lib/decidim/term_customizer/context/job_context.rb
@@ -8,14 +8,21 @@ module Decidim
         def resolve!
           # Figure out the organization and user through the job arguments if
           # passed for the job.
-          user = nil
+          arguments = {
+            organization: nil,
+            space: nil,
+            component: nil,
+            user: nil
+          }
+
           data[:job].arguments.each do |arg|
-            @organization ||= organization_from_argument(arg)
-            @space ||= space_from_argument(arg)
-            @component ||= component_from_argument(arg)
-            user ||= arg if arg.is_a?(Decidim::User)
+            arg = arg.fetch(:args, []) if arg.is_a?(Hash) && arg.has_key?(:args)
+            arguments = arguments_for(arg)
           end
 
+          @organization ||= arguments[:organization]
+          @space ||= arguments[:space]
+          @component ||= arguments[:component]
           # In case a component was found, define the space as the component
           # space to avoid any conflicts.
           @space = component.participatory_space if component
@@ -26,11 +33,27 @@ module Decidim
 
           # In case an organization could not be resolved any other way, check
           # it through the user (if the user was passed).
-          @organization ||= user.organization if user
+          @organization ||= arguments[:user]&.organization if arguments[:user]
         end
+
         # rubocop:enable Metrics/PerceivedComplexity
 
         protected
+
+        def arguments_for(args)
+          return conf_for_arg(args.last) if args.is_a?(Array)
+
+          conf_for_arg(args)
+        end
+
+        def conf_for_arg(arg)
+          {
+            organization: organization_from_argument(arg),
+            space: space_from_argument(arg),
+            component: component_from_argument(arg),
+            user: arg.is_a?(Decidim::User) ? arg : nil
+          }
+        end
 
         def organization_from_argument(arg)
           return arg if arg.is_a?(Decidim::Organization)

--- a/lib/decidim/term_customizer/context/job_context.rb
+++ b/lib/decidim/term_customizer/context/job_context.rb
@@ -10,7 +10,7 @@ module Decidim
           # passed for the job.
           user = nil
           data[:job].arguments.each do |arg|
-            arg = arg[:args].first if arg.is_a?(Hash)
+            arg = arg[:args].first if arg.is_a?(Hash) && arg.has_key?(:args)
 
             @organization ||= organization_from_argument(arg)
             @space ||= space_from_argument(arg)

--- a/spec/lib/decidim/term_customizer/context/job_context_spec.rb
+++ b/spec/lib/decidim/term_customizer/context/job_context_spec.rb
@@ -135,4 +135,14 @@ describe Decidim::TermCustomizer::Context::JobContext do
       expect(subject.component).to be(component)
     end
   end
+
+  context "with object having arguments passed as Hash" do
+    let(:arguments) { [args: [organization]] }
+
+    it "resolves the organization" do
+      expect(subject.organization).to be(organization)
+      expect(subject.space).to be_nil
+      expect(subject.component).to be_nil
+    end
+  end
 end

--- a/spec/lib/decidim/term_customizer/context/job_context_spec.rb
+++ b/spec/lib/decidim/term_customizer/context/job_context_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::TermCustomizer::Context::JobContext do
   let(:data) { { job: job } }
   let(:job) { double }
   let(:organization) { create(:organization) }
+  let(:arguments) { [organization] }
 
   before do
     allow(job).to receive(:arguments).and_return(arguments)
@@ -151,6 +152,19 @@ describe Decidim::TermCustomizer::Context::JobContext do
     let(:arguments) { ["Decidim::DecidimDeviseMailer", "reset_password_instructions", "deliver_now", { args: [user] }] }
 
     it "resolves the user's organization" do
+      expect(subject.organization).not_to be(organization)
+      expect(subject.organization).to be(user.organization)
+      expect(subject.space).to be_nil
+      expect(subject.component).to be_nil
+    end
+  end
+
+  context "with a resource that does not contain args" do
+    let(:user) { create(:user) }
+    let(:arguments) { ["Decidim::DecidimDeviseMailer", "reset_password_instructions", "deliver_now", user] }
+
+    it "resolves the user's organization" do
+      expect(arguments).not_to respond_to(:args)
       expect(subject.organization).not_to be(organization)
       expect(subject.organization).to be(user.organization)
       expect(subject.space).to be_nil

--- a/spec/lib/decidim/term_customizer/context/job_context_spec.rb
+++ b/spec/lib/decidim/term_customizer/context/job_context_spec.rb
@@ -145,4 +145,16 @@ describe Decidim::TermCustomizer::Context::JobContext do
       expect(subject.component).to be_nil
     end
   end
+
+  context "with a list of arguments" do
+    let(:user) { create(:user) }
+    let(:arguments) { ["Decidim::DecidimDeviseMailer", "reset_password_instructions", "deliver_now", { args: [user] }] }
+
+    it "resolves the user's organization" do
+      expect(subject.organization).not_to be(organization)
+      expect(subject.organization).to be(user.organization)
+      expect(subject.space).to be_nil
+      expect(subject.component).to be_nil
+    end
+  end
 end

--- a/spec/lib/decidim/term_customizer/engine_spec.rb
+++ b/spec/lib/decidim/term_customizer/engine_spec.rb
@@ -169,25 +169,6 @@ describe Decidim::TermCustomizer::Engine do
           dummy_data
         )
       end
-
-      context "and user does not belong to the organization" do
-        let(:user) { create(:user) }
-
-        it "creates a resolver with the user's organization" do
-          allow(Decidim::TermCustomizer::Resolver).to receive(:new).with(
-            user.organization,
-            nil,
-            nil
-          ).and_return(resolver)
-          expect(Decidim::TermCustomizer::Loader).to receive(:new).with(resolver)
-          expect(dummy_backend).to receive(:reload!)
-
-          ActiveSupport::Notifications.instrument(
-            "perform_start.active_job",
-            dummy_data
-          )
-        end
-      end
     end
   end
 

--- a/spec/lib/decidim/term_customizer/engine_spec.rb
+++ b/spec/lib/decidim/term_customizer/engine_spec.rb
@@ -152,7 +152,7 @@ describe Decidim::TermCustomizer::Engine do
 
     context "with user and organization in the arguments" do
       let(:organization) { create(:organization) }
-      let(:user) { create(:user) }
+      let(:user) { create(:user, organization: organization) }
       let(:arguments) { [organization, user] }
 
       it "creates a resolver with the organization" do
@@ -168,6 +168,25 @@ describe Decidim::TermCustomizer::Engine do
           "perform_start.active_job",
           dummy_data
         )
+      end
+
+      context "and user does not belong to the organization" do
+        let(:user) { create(:user) }
+
+        it "creates a resolver with the user's organization" do
+          allow(Decidim::TermCustomizer::Resolver).to receive(:new).with(
+            user.organization,
+            nil,
+            nil
+          ).and_return(resolver)
+          expect(Decidim::TermCustomizer::Loader).to receive(:new).with(resolver)
+          expect(dummy_backend).to receive(:reload!)
+
+          ActiveSupport::Notifications.instrument(
+            "perform_start.active_job",
+            dummy_data
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
#### Description

Current version does not allow to translate Devise emails translations (subjects, etc...)

`Decidim::TermCustomizer::Context::JobContext` doesn't handle the Devise job arguments format. At the moment, it expects Decidim jobs to have as argument a `Decidim::Organization` or `Decidim::User` in method `resolve!`.

I found that Devise mailer jobs contains a list of arguments and the expected argument in a Hash `{ args: [Decidim::User] }` for example.

#### Related to 

* #93 

#### How to test

Create multiple devise translation customizations : 

**For account confirmation mails :** 

Create TermCustomizer entries
* `devise.mailer.confirmation_instructions.instruction`
* `devise.mailer.confirmation_instructions.subject `

Refresh cache and create a new account

**For reset password confirmation :** 
Create TermCustomizer entries
* `devise.mailer.reset_password_instructions.subject`

Refresh cache and ask a reset password for `user@example.org`

**For new admin invitation**
Create TermCustomizer entries
* `devise.mailer.invite_admin.subject`

Refresh cache and invite a new admin


