### PR TITLE
fix: multi threading compliance

### DIFF
--- a/app/controllers/decidim/term_customizer/admin/caches_controller.rb
+++ b/app/controllers/decidim/term_customizer/admin/caches_controller.rb
@@ -13,7 +13,8 @@ module Decidim
         def clear
           enforce_permission_to :update, :organization
 
-          TermCustomizer.loader.clear_cache
+          resolver = TermCustomizer::Resolver.new(current_organization, nil, nil)
+          Loader.new(resolver).clear_cache
           flash[:notice] = I18n.t("caches.clear.success", scope: "decidim.term_customizer.admin")
 
           redirect_to translation_sets_path

--- a/lib/decidim/term_customizer/engine.rb
+++ b/lib/decidim/term_customizer/engine.rb
@@ -7,9 +7,11 @@ module Decidim
 
       initializer "decidim_term_customizer.setup" do
         customizer_backend = Decidim::TermCustomizer::I18nBackend.new
+        i18n_backend = I18n.backend
+
         I18n.backend = I18n::Backend::Chain.new(
           customizer_backend,
-          I18n.backend
+          i18n_backend
         )
 
         # Setup a controller hook to setup the term customizer before the
@@ -27,10 +29,10 @@ module Decidim
           )
 
           # Create the loader for the backend to fetch the translations from
-          TermCustomizer.loader = Loader.new(resolver)
+          I18n.backend.backends.first.loader = Loader.new(resolver)
 
           # Force the backend to reload the translations for the current request
-          customizer_backend.reload!
+          I18n.backend.backends.first.reload!
         end
 
         # The jobs are generally run in different context than the controllers
@@ -57,10 +59,10 @@ module Decidim
           )
 
           # Create the loader for the backend to fetch the translations from
-          TermCustomizer.loader = Loader.new(resolver)
+          I18n.backend.backends.first.loader = Loader.new(resolver)
 
-          # Force the backend to reload the translations for the job
-          customizer_backend.reload!
+          # Force the backend to reload the translations for the current request
+          I18n.backend.backends.first.reload!
         end
       end
     end

--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -19,6 +19,10 @@ module Decidim
           []
         end
 
+        def loader=(loader)
+          @loader = loader
+        end
+
         def initialized?
           !@translations.nil?
         end
@@ -31,9 +35,9 @@ module Decidim
 
         def translations
           return @translations if @translations
-          return {} unless TermCustomizer.loader
+          return {} unless @loader
 
-          @translations = TermCustomizer.loader.translations_hash
+          @translations = @loader.translations_hash
         end
 
         protected

--- a/spec/controllers/decidim/term_customizer/admin/caches_controller_spec.rb
+++ b/spec/controllers/decidim/term_customizer/admin/caches_controller_spec.rb
@@ -27,13 +27,8 @@ module Decidim
       end
 
       describe "DELETE clear" do
-        let(:loader) { double }
 
         it "clears the cache and redirects to the translation sets path" do
-          allow(TermCustomizer).to receive(:loader).and_return(loader)
-          allow(loader).to receive(:translations_hash).and_return({})
-          expect(loader).to receive(:clear_cache)
-
           delete :clear
 
           expect(response).to have_http_status(:found)

--- a/spec/lib/decidim/term_customizer/engine_spec.rb
+++ b/spec/lib/decidim/term_customizer/engine_spec.rb
@@ -39,7 +39,7 @@ describe Decidim::TermCustomizer::Engine do
 
     before do
       allow(Decidim::TermCustomizer::I18nBackend).to receive(:new).and_return(dummy_backend)
-
+      allow(dummy_backend).to receive(:loader=)
       run_initializer
 
       allow(dummy_data_headers).to receive(:env).and_return(dummy_env)
@@ -120,7 +120,7 @@ describe Decidim::TermCustomizer::Engine do
           nil,
           nil
         ).and_return(resolver)
-        expect(Decidim::TermCustomizer::Loader).to receive(:new).with(resolver)
+        allow(dummy_backend).to receive(:loader=).with(Decidim::TermCustomizer::Loader)
         expect(dummy_backend).to receive(:reload!)
 
         ActiveSupport::Notifications.instrument(
@@ -140,7 +140,7 @@ describe Decidim::TermCustomizer::Engine do
           nil,
           nil
         ).and_return(resolver)
-        expect(Decidim::TermCustomizer::Loader).to receive(:new).with(resolver)
+        allow(dummy_backend).to receive(:loader=).with(Decidim::TermCustomizer::Loader)
         expect(dummy_backend).to receive(:reload!)
 
         ActiveSupport::Notifications.instrument(
@@ -161,7 +161,7 @@ describe Decidim::TermCustomizer::Engine do
           nil,
           nil
         ).and_return(resolver)
-        expect(Decidim::TermCustomizer::Loader).to receive(:new).with(resolver)
+        allow(dummy_backend).to receive(:loader=).with(Decidim::TermCustomizer::Loader)
         expect(dummy_backend).to receive(:reload!)
 
         ActiveSupport::Notifications.instrument(

--- a/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
+++ b/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
@@ -89,8 +89,8 @@ describe Decidim::TermCustomizer::I18nBackend do
       let(:loader) { double }
 
       before do
-        allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
         allow(loader).to receive(:translations_hash).and_return([])
+        subject.loader = loader
       end
 
       it "returns true" do
@@ -104,8 +104,8 @@ describe Decidim::TermCustomizer::I18nBackend do
     let(:loader) { double }
 
     before do
-      allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
       allow(loader).to receive(:translations_hash).and_return([])
+      subject.loader = loader
     end
 
     it "resets the translations" do
@@ -120,8 +120,8 @@ describe Decidim::TermCustomizer::I18nBackend do
     let(:loader) { double }
 
     before do
-      allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
       allow(loader).to receive(:translations_hash).and_return(translations_list)
+      subject.loader = loader
     end
 
     it "returns the correct translations list" do
@@ -139,8 +139,8 @@ describe Decidim::TermCustomizer::I18nBackend do
       let(:loader) { double }
 
       before do
-        allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
         allow(loader).to receive(:translations_hash).and_return(translations_list)
+        subject.loader = loader
       end
 
       it "translates the translation keys correctly" do
@@ -157,8 +157,8 @@ describe Decidim::TermCustomizer::I18nBackend do
       let(:loader) { double }
 
       before do
-        allow(Decidim::TermCustomizer).to receive(:loader).and_return(loader)
         allow(loader).to receive(:translations_hash).and_return(pluralize_translations_list)
+        subject.loader = loader
       end
 
       it "translates the translation keys correctly" do


### PR DESCRIPTION
#### Description 

The current implementation isn't thread-safe. On multi-threaded decidim application users may find inconsistencies on the modified translations.
I was able to reproduce a race condition on the proposals index view. Modifying the translation of `decidim.proposals.application_helper.filter_state_values.evaluating` and using a scraper inspecting the label text with 4 threads and 100 requests per thread.

#### Related to 

#107 

#### Testing 

- Modify a translation 
- Activate cache
- Enable multi-threading on application
- Make multiple concurrent requests on application

#### Additional information

I tested with different environments : 
- single thread puma
- 5 threads puma
- 4 workers and 5 threads per worker puma

I am not sure the current PR is fully thread-safe but I notice a reduction of inconsistencies.

I can share the application used with different configuration, and also the scraper used if wanted