### PR TITLE
Fix/redirect to current page after edit

### DIFF
--- a/app/controllers/decidim/term_customizer/admin/translations_controller.rb
+++ b/app/controllers/decidim/term_customizer/admin/translations_controller.rb
@@ -51,11 +51,12 @@ module Decidim
             current_organization: current_organization,
             translation_set: set
           )
+          page_param = params[:translation][:page]
 
           UpdateTranslation.call(@form, translation) do
             on(:ok) do
               flash[:notice] = I18n.t("translations.update.success", scope: "decidim.term_customizer.admin")
-              redirect_to translation_set_translations_path(set)
+              redirect_to translation_set_translations_path(set, page: page_param)
             end
 
             on(:invalid) do

--- a/app/controllers/decidim/term_customizer/admin/translations_controller.rb
+++ b/app/controllers/decidim/term_customizer/admin/translations_controller.rb
@@ -51,12 +51,12 @@ module Decidim
             current_organization: current_organization,
             translation_set: set
           )
-          page_param = params[:translation][:page]
 
           UpdateTranslation.call(@form, translation) do
             on(:ok) do
               flash[:notice] = I18n.t("translations.update.success", scope: "decidim.term_customizer.admin")
-              redirect_to translation_set_translations_path(set, page: page_param)
+
+              redirect_to redirect_path_for_set(set)
             end
 
             on(:invalid) do
@@ -137,6 +137,15 @@ module Decidim
 
         def translation
           @translation ||= Decidim::TermCustomizer::Translation.find(params[:id])
+        end
+
+        def redirect_path_for_set(set)
+          page_param = params[:translation][:page]
+          if page_param.nil?
+            translation_set_translations_path(set)
+          else
+            translation_set_translations_path(set, page: page_param)
+          end
         end
 
         alias collection translations

--- a/app/views/decidim/term_customizer/admin/translations/_form.html.erb
+++ b/app/views/decidim/term_customizer/admin/translations/_form.html.erb
@@ -37,5 +37,6 @@
     <div class="row column">
       <%= form.translated :text_area, :value, rows: 4 %>
     </div>
+    <%= form.hidden_field :page, value: params[:page] %>
   </div>
 </div>

--- a/app/views/decidim/term_customizer/admin/translations/index.html.erb
+++ b/app/views/decidim/term_customizer/admin/translations/index.html.erb
@@ -61,7 +61,7 @@
                 </td>
                 <td class="table-list__actions">
                   <% if allowed_to? :update, :translation, translation: translation %>
-                    <%= icon_link_to "pencil", edit_translation_set_translation_path(set, translation), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
+                    <%= icon_link_to "pencil", edit_translation_set_translation_path(set, translation, page: params[:page]), t("actions.configure", scope: "decidim.admin"), class: "action-icon--new" %>
                   <% end %>
 
                   <% if allowed_to? :destroy, :translation, translation: translation %>

--- a/lib/decidim/term_customizer/test/rspec_support/capybara.rb
+++ b/lib/decidim/term_customizer/test/rspec_support/capybara.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "selenium-webdriver"
+
+module Decidim
+  # This is being added because of the issues with the chrome-driver
+  # in version 120 or later, and this can be removed after this pr#12160
+  # being merged(more info https://github.com/decidim/decidim/pull/12159).
+  Capybara.register_driver :headless_chrome do |app|
+    options = ::Selenium::WebDriver::Chrome::Options.new
+    options.args << "--headless=new"
+    options.args << "--no-sandbox"
+    options.args << if ENV["BIG_SCREEN_SIZE"].present?
+                      "--window-size=1920,3000"
+                    else
+                      "--window-size=1920,1080"
+                    end
+    options.args << "--ignore-certificate-errors" if ENV["TEST_SSL"]
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      capabilities: [options]
+    )
+  end
+end

--- a/spec/controllers/decidim/term_customizer/admin/translations_controller_spec.rb
+++ b/spec/controllers/decidim/term_customizer/admin/translations_controller_spec.rb
@@ -77,11 +77,25 @@ module Decidim
           put :update, params: params.merge(
             id: translation.id,
             key: "updated.translation.key",
-            value: { en: "Lorem ipsum dolor" }
+            value: { en: "Lorem ipsum dolor" },
+            translation: { page: nil }
           )
 
           expect(flash[:notice]).not_to be_empty
           expect(response).to have_http_status(:found)
+        end
+
+        context "when page params exist" do
+          it "redirects to the same paginated page" do
+            put :update, params: params.merge(
+              id: translation.id,
+              key: "updated.translation.key",
+              value: { en: "Lorem ipsum dolor" },
+              translation: { page: "2" }
+            )
+
+            expect(response).to redirect_to("/sets/#{translation_set.id}/translations?page=2")
+          end
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ Decidim::Dev.dummy_app_path =
   File.expand_path(File.join(__dir__, "decidim_dummy_app"))
 
 require "decidim/dev/test/base_spec_helper"
+# This is being added because of the issues with the chrome-driver
+# in version 120 or later, and this can be removed after this pr#12160
+# being merged(more info https://github.com/decidim/decidim/pull/12159).
+require "#{Dir.pwd}/lib/decidim/term_customizer/test/rspec_support/capybara.rb"
 
 RSpec.configure do |config|
   # Add extra traslation load path for the tests


### PR DESCRIPTION
When editing the multi-page translation, the update redirects to the first page. This pr fixes this issue and redirects to the same page in view after editing.
This pr fixes issue #101 