### PR TITLE
Fix ArgumentError on clear_cache

### DIFF
--- a/lib/decidim/term_customizer/loader.rb
+++ b/lib/decidim/term_customizer/loader.rb
@@ -62,7 +62,7 @@ module Decidim
       # the resolver.
       def clear_cache
         Rails.cache.delete_matched("#{cache_key_base}/*")
-      rescue NotImplementedError, NoMethodError
+      rescue NotImplementedError, NoMethodError, ArgumentError
         # Some cache store, such as `ActiveSupport::Cache::MemCacheStore` or
         # `ActiveSupport::Cache::DalliStore` do not support `delete_matched`.
         # Therefore, clear all the possibly existing

--- a/spec/lib/decidim/term_customizer/loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/loader_spec.rb
@@ -182,6 +182,74 @@ describe Decidim::TermCustomizer::Loader do
       end
     end
 
+    # FileStore implements `delete_matched` but can raise `ArgumentError` when
+    # traversing cache files whose keys contain URL-encoded sequences (e.g.
+    # ActiveStorage pre-signed S3 URLs) split across directory chunks.
+    context "when using file_store with invalid %-encoding cache files" do
+      let(:mock_cache) { ActiveSupport::Cache::MemoryStore.new }
+
+      before do
+        allow(mock_cache).to receive(:delete_matched).and_raise(ArgumentError, "invalid %-encoding")
+        allow(Rails).to receive(:cache).and_return(mock_cache)
+      end
+
+      context "without organization" do
+        let(:organization) { nil }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/system"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization" do
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization and space" do
+        let(:space) { create(:participatory_process, organization:) }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization, space and component" do
+        let(:space) { create(:participatory_process, organization:) }
+        let(:component) { create(:proposal_component, participatory_space: space) }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}/component_#{component.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+    end
+
     # The DalliStore does not implement `delete_matched` which allows us to
     # test the `clear_cache` functionality when the cache implementation raises
     # a `NoMethodError`.


### PR DESCRIPTION
## Why

`ActiveSupport::Cache::FileStore` implements `delete_matched` but can raise
`ArgumentError: invalid %-encoding` when traversing cache files whose keys
contain URL-encoded sequences (e.g. ActiveStorage pre-signed S3 URLs) that
get split across directory chunks.

This causes `Loader#clear_cache` to raise an unhandled exception, which
surfaces as an error to the admin user.

## How to reproduce

**Prerequisites:** The application must be using `ActiveSupport::Cache::FileStore`
as the cache store, and there must be cached entries whose keys contain
URL-encoded characters (e.g. ActiveStorage pre-signed S3 URLs stored as part
of a cache key). These keys get split into directory chunks by FileStore, and
when any chunk contains an invalid `%`-encoded sequence, Ruby's `URI.decode`
raises `ArgumentError: invalid %-encoding`.

**Steps:**
1. Go to Term Customizer
2. Click **Clear cache**

**Result:** `ArgumentError: invalid %-encoding (...)` is raised from within
`FileStore#delete_matched` and propagates uncaught, causing a 500 error.

**Expected:** Cache is cleared successfully (or falls back gracefully).

## What

Add `ArgumentError` to the rescue clause in `Loader#clear_cache` so it falls
back to the existing manual per-key deletion path — the same way
`NotImplementedError` (MemCacheStore) and `NoMethodError` (DalliStore) are
already handled.

```ruby
# Before
rescue NotImplementedError, NoMethodError

# After
rescue NotImplementedError, NoMethodError, ArgumentError