### PR TITLE
Fix to rescue ActiveRecord::ConnectionNotEstablished in available_locales

### DIFF
--- a/lib/decidim/term_customizer/i18n_backend.rb
+++ b/lib/decidim/term_customizer/i18n_backend.rb
@@ -15,7 +15,7 @@ module Decidim
         # Get available locales from the translations hash
         def available_locales
           Translation.available_locales
-        rescue ::ActiveRecord::StatementInvalid
+        rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::ConnectionNotEstablished
           []
         end
 

--- a/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
+++ b/spec/lib/decidim/term_customizer/i18n_backend_spec.rb
@@ -76,6 +76,16 @@ describe Decidim::TermCustomizer::I18nBackend do
         expect(subject.available_locales).to be_empty
       end
     end
+
+    context "when the translation query raises ActiveRecord::ConnectionNotEstablished" do
+      it "returns an empty result" do
+        allow(Decidim::TermCustomizer::Translation).to receive(
+          :available_locales
+        ).and_raise(ActiveRecord::ConnectionNotEstablished)
+
+        expect(subject.available_locales).to be_empty
+      end
+    end
   end
 
   describe "#initialized?" do


### PR DESCRIPTION
Fixes #133 
